### PR TITLE
Initial build 0.0.32

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,13 +42,16 @@ test:
     - python -m pytest --tb=native --pyargs {{ modulename }}
 
 about:
-  home: http://github.com/explosion/spacy-pkuseg
+  home: https://github.com/explosion/spacy-pkuseg
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: PKUSeg Chinese word segmentation toolkit for spaCy
-
-  doc_url: https://github.com/explosion/spacy-pkuseg
+  description: |
+    This package is a fork of pkuseg-python that simplifies installation
+    and serialization for use with spaCy. The underlying segmentation
+    tools remain unmodified.
+  doc_url: https://github.com/explosion/spacy-pkuseg/blob/master/readme/readme_english.md
   dev_url: https://github.com/explosion/spacy-pkuseg
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256sum }}
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - python
     - {{ pin_compatible('numpy') }}
     - srsly >=2.3.0,<3.0.0
-    - cython
 
 test:
   imports:


### PR DESCRIPTION
[Upstream repo](https://github.com/explosion/spacy-pkuseg)
[Jira Issue](https://anaconda.atlassian.net/browse/PKG-2024)

`medspacy` <- `spacy-models` <- `spacy-pkuseg`

Very minor changes from conda-forge. Linter wants a compiler for `cython`, but there already is one in the recipe, so it's probably a linter bug.