### PR TITLE
spacy-pkuseg 1.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "spacy-pkuseg" %}
 {% set modulename = "spacy_pkuseg" %}
-{% set version = "0.0.32" %}
-{% set sha256sum = "f72d9365138e9083a5e78bba8e87190f85ad3f90adddb55f69c58aa862c8484c" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name }}
@@ -9,11 +8,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/{{ name }}/{{ modulename }}-{{ version }}.tar.gz
-  sha256: {{ sha256sum }}
+  sha256: 33531ea8e13fc09ebe3b40bd97e84d07ccd5a1fe67fa8e84173769a25ac03158
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -24,11 +23,11 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - cython
-    - numpy
+    - cython >=0.25
+    - numpy >=2.0.0,<3.0.0
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy >=2.0.0,<3.0.0
     - srsly >=2.3.0,<3.0.0
 
 test:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-6019](https://anaconda.atlassian.net/browse/PKG-6019) 
- [Upstream repository](https://github.com/explosion/spacy-pkuseg/tree/release-v1.0.0)
- Requirements: https://github.com/explosion/spacy-pkuseg/blob/release-v1.0.0/setup.cfg

### Explanation of changes:

- Skip py<39
- Use `numpy >=2.0.0,<3.0.0` in `host` and `run`

### Notes:

- spacy-models 3.8.0 requires it

[PKG-6019]: https://anaconda.atlassian.net/browse/PKG-6019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ